### PR TITLE
ci(codeql): fix Go version discrepancy

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,9 +31,9 @@ jobs:
         language:
           - go
     steps:
-      - uses: actions/checkout@v3
-      - uses: github/codeql-action/init@v2
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
         with:
           languages: "${{ matrix.language }}"
-      - uses: github/codeql-action/autobuild@v2
-      - uses: github/codeql-action/analyze@v2
+      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## About this change - What it does

Fixes codeql error message about "Newer Go version needed"


