### PR TITLE
docs(security): change bugbounty provider from h1 to bugcrowd

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ CVSS v3.0 Rating:
 
 ## Reporting a Vulnerability
 
-Please report (suspected) security vulnerabilities to our **[bug bounty program](https://hackerone.com/aiven_ltd)**.
+Please report (suspected) security vulnerabilities to our **[bug bounty program](https://bugcrowd.com/aiven-mbb-og)**.
 You will receive a response from us within 2 working days. If the issue is confirmed, we will release a patch as soon
 as possible depending on impact and complexity.
 


### PR DESCRIPTION
## About this change - What it does

Our bugbounty program is now with Bugcrowd. The HackerOne program is deprecated.
