### PR TITLE
ci(changelog-enforce): drop for trunk pull requests

### DIFF
--- a/.github/workflows/changelog-enforce.yml
+++ b/.github/workflows/changelog-enforce.yml
@@ -23,4 +23,4 @@ jobs:
     steps:
       - uses: dangoslen/changelog-enforcer@v3
         with:
-          skipLabels: no changelog
+          skipLabels: no changelog, trunk


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->

## About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
drops Changelog Enforce for PRs made by Trunk

<!-- Provide the issue number below if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
it's counter-productive to add `no changelog` label to those PRs
